### PR TITLE
Fix swift example project start/stop and pause/resume

### DIFF
--- a/Example-swift/AcaiaViewController.swift
+++ b/Example-swift/AcaiaViewController.swift
@@ -149,13 +149,14 @@ extension AcaiaViewController {
             } else {
                 _pauseTimerButton.isEnabled = true;
                 scale.startTimer()
+                _isTimerStarted = true;
                 _timerButton.setTitle("Stop Timer", for: UIControl.State.normal)
             }
         }
     }
     
     @IBAction private func _onBtnPauseTimer() {
-        if let scale = AcaiaManager.shared().scaleList.first {
+        if let scale = AcaiaManager.shared().connectedScale {
             if _isTimerPaused {
                 _isTimerPaused = false
                 scale.startTimer()

--- a/Example-swift/AcaiaViewController.swift
+++ b/Example-swift/AcaiaViewController.swift
@@ -126,7 +126,7 @@ extension AcaiaViewController {
     }
     
     @objc private func _onTimer(noti: NSNotification) {
-        guard let time = noti.userInfo?["time"] as? Int else { return }
+        let time = noti.userInfo![AcaiaScaleUserInfoKeyTimer]! as! Int
         _timerLabel.text = String(format: "%02d:%02d", time/60, time%60)
         _isTimerStarted = true;
     }


### PR DESCRIPTION
The swift example project does not handle the timer stop or pause/resume correctly. This PR fixes this.

Resolves #8 

Also added a fix for the timer not being updated.