### PR TITLE
Update package manifest to fix a quirk in Xcode 13.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,27 +3,18 @@
 
 import PackageDescription
 
-
 let package = Package(
-    
-    name: "acaia_sdk_ios",
-    
+    name: "AcaiaSDK",
     products: [
         .library(
-            name: "acaia_sdk_ios",
-            targets: ["acaia_sdk_ios"]
+            name: "AcaiaSDK",
+            targets: ["AcaiaSDK"]
         ),
     ],
-    
     targets: [
         .binaryTarget(
-            name: "acaia_sdk_ios",
+            name: "AcaiaSDK",
             path: "AcaiaSDK.xcframework"
         ),
-        
-//        .testTarget(
-//            name: "acaia_sdk_iosTests",
-//            dependencies: ["acaia_sdk_ios"]
-//        ),
     ]
 )


### PR DESCRIPTION
When you have the old package as a dependency inside your app, and try to run in Xcode 13.3, the application will not build due to a missing artefact.

This problem is not isolated to Acaia as can be seen [here](https://support.zendesk.com/hc/en-us/community/posts/4429572484762-Xcode-13-3-Beta-3-artifact-not-found-for-target), but it would be great to get it fixed. The fix is minimal and has no effect on the examples as they use pods anyway.